### PR TITLE
Extend wrapper to receive logger tag and syslog facility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.5.0
+
+* Allow custom logger name and facility.
+
 ## 0.1.4.0
 
 * Support for hsyslog-5

--- a/README.md
+++ b/README.md
@@ -9,10 +9,22 @@
 
 ## Usage (example)
 
+### Default to syslog `user` facility with name `hslogger`
+
 ```haskell
 import Control.Monad.Logger ( logDebugN  )
 import Control.Monad.Logger.Syslog ( runSyslogLoggingT )
 
 main :: IO ()
 main = runSyslogLoggingT (logDebugN "HELLO!")
+```
+
+### Log under `Local1` facility with name `mylogger`
+
+```haskell
+import Control.Monad.Logger ( logDebugN  )
+import Control.Monad.Logger.Syslog ( runCustomSyslogLoggingT )
+
+main :: IO ()
+main = runCustomSyslogLoggingT "mylogger" Local1 (logDebugN "HELLO!")
 ```

--- a/monad-logger-syslog.cabal
+++ b/monad-logger-syslog.cabal
@@ -1,5 +1,5 @@
 name:                monad-logger-syslog
-version:             0.1.4.0
+version:             0.1.5.0
 synopsis:            syslog output for monad-logger
 description:         syslog output for monad-logger
 homepage:            https://github.com/fpco/monad-logger-syslog

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,8 @@ flags:
 packages:
 - '.'
 extra-deps: []
-resolver: lts-7.5
+resolver: lts-14.13
+# resolver: lts-13.19
+# resolver: lts-12.26
+# resolver: lts-11.22
+# resolver: lts-7.24


### PR DESCRIPTION
- New `runCustomSyslogLoggingT` takes explicit name (logger «tag») and Syslog facility. Now `runSyslogLoggingT` implicitly uses "hslogger" and 'User', respectively, for backwards compatibility.
- Re-export `System.Posix.Syslog.Facility` as a convenience for using `runCustomSyslogLoggingT`.
- Added usage notes and example to `README.md`
- Tested with hsyslog-5.0 (lts-14.13, lts-13.19, lts-12.26, lts-11.22, and lts-9.21) and hsyslog-4.0 (lts-7.24)