### PR TITLE
Update dependency bounds to build with LTS-23

### DIFF
--- a/System/Log/MonadLogger/Syslog.hs
+++ b/System/Log/MonadLogger/Syslog.hs
@@ -10,13 +10,13 @@ module System.Log.MonadLogger.Syslog
 
 import Control.Monad.Logger
 import Data.Text             ( unpack )
-import System.Log.FastLogger ( fromLogStr )
 import System.Posix.Syslog
 
 #if MIN_VERSION_hsyslog(5,0,0)
 import qualified Data.ByteString.Unsafe as BSU
 #else
 import qualified Data.ByteString.Char8 as BS8
+import           System.Log.FastLogger ( fromLogStr )
 #endif
 
 -- | Runs a 'LoggingT' action, sending its output to Syslog.

--- a/monad-logger-syslog.cabal
+++ b/monad-logger-syslog.cabal
@@ -1,5 +1,5 @@
 name:                monad-logger-syslog
-version:             0.1.6.0
+version:             0.1.6.1
 synopsis:            syslog output for monad-logger
 description:         syslog output for monad-logger
 homepage:            https://github.com/fpco/monad-logger-syslog
@@ -22,9 +22,9 @@ library
                        System.Log.MonadLogger.Syslog
   ghc-options:        -Wall
   build-depends:       base < 10
-                     , bytestring          >= 0.10.8 && < 0.11
+                     , bytestring          >= 0.10.8 && < 0.13
                      , fast-logger         >= 2.4.7
-                     , text                >= 1.2.2 && < 1.3
-                     , hsyslog             >= 4     && < 5.1
+                     , text                >= 1.2.2
+                     , hsyslog             >= 4      && < 5.1
                      , monad-logger        >= 0.3.20 && < 0.4
-                     , transformers        >= 0.5.2 && < 0.6
+                     , transformers        >= 0.5.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,8 +3,11 @@ flags:
 packages:
 - '.'
 extra-deps: []
-# Supports GHC 8 only
-resolver: lts-14.15
+
+resolver: lts-23.9
+# resolver: lts-22.43
+# resolver: lts-16.26
+# resolver: lts-14.15
 # resolver: lts-13.19
 # resolver: lts-12.26
 # resolver: lts-11.22


### PR DESCRIPTION
I've been updating `monad-logger-syslog` by bumping dependency bounds as newer LTS come out. So far it has worked for me with GHC 9.x using a local version. I would like to have `monad-logger-syslog` back into Stackage.

I wonder if setting version 0.1.7.0 makes sense or not.